### PR TITLE
fix: mobile keyboard handling for PWA chat input

### DIFF
--- a/src/client/index.html
+++ b/src/client/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover, interactive-widget=resizes-content">
   <meta name="theme-color" content="#cba6f7">
   <meta name="description" content="Remote control for GitHub Copilot CLI">
   <title>Copilot Uplink</title>

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -455,6 +455,25 @@ async function handleSessionCommand(arg: string): Promise<void> {
   }
 }
 
+// ─── Mobile keyboard handling ─────────────────────────────────────────
+// Chrome/Edge: VirtualKeyboard API gives env(keyboard-inset-height) in CSS.
+// Safari/iOS:  dvh doesn't track the keyboard, so we sync #app to the
+//              visual viewport — height for the keyboard, translateY for
+//              the scroll offset iOS applies when focusing an input.
+const appEl = document.getElementById('app')!;
+
+if ('virtualKeyboard' in navigator) {
+  (navigator as any).virtualKeyboard.overlaysContent = true;
+} else if (window.visualViewport) {
+  const vv = window.visualViewport;
+  const sync = () => {
+    appEl.style.height = `${vv.height}px`;
+    appEl.style.transform = `translateY(${vv.offsetTop}px)`;
+  };
+  vv.addEventListener('resize', sync);
+  vv.addEventListener('scroll', sync);
+}
+
 // ─── Connect ──────────────────────────────────────────────────────────
 
 updateConnectionStatus('disconnected');

--- a/src/client/style.css
+++ b/src/client/style.css
@@ -19,6 +19,7 @@
   --text-sm: 0.8rem;    /* 12.8px — metadata, secondary info */
   --text-base: 0.85rem; /* 13.6px — body text, menus */
   --text-md: 0.9rem;    /* 14.4px — input, buttons, primary content */
+  --text-input: 1rem;   /* 16px   — textarea; ≥16px prevents iOS auto-zoom */
   --text-lg: 1.1rem;    /* 17.6px — subheadings */
   --text-xl: 1.2rem;    /* 19.2px — headings */
 
@@ -100,6 +101,7 @@ body, html {
   background-color: var(--bg-primary);
   color: var(--text-primary);
   overflow: hidden;
+  touch-action: none;          /* prevent stray pinch/pan on the root */
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
@@ -126,13 +128,15 @@ body, html {
 #app {
   display: flex;
   flex-direction: column;
-  position: fixed;
-  top: 0;
-  bottom: 0;
-  left: max(0px, calc(50% - 400px));
-  right: max(0px, calc(50% - 400px));
+  height: 100vh;                       /* fallback for older browsers */
+  height: 100dvh;                      /* shrinks when mobile keyboard opens */
+  max-width: 800px;
+  margin: 0 auto;
   padding-left: env(safe-area-inset-left, 0px);
   padding-right: env(safe-area-inset-right, 0px);
+  overflow: hidden;
+  will-change: height, transform;
+  transition: height 0.25s ease-out, transform 0.25s ease-out;
 }
 
 /* Header */
@@ -223,6 +227,8 @@ body, html {
   flex-direction: column;
   gap: var(--space-4);
   scroll-behavior: smooth;
+  touch-action: pan-y;         /* allow vertical scroll, prevent zoom */
+  -webkit-overflow-scrolling: touch;
 }
 
 .chat-container {
@@ -332,7 +338,9 @@ pre code {
 /* Input Area */
 #input-area {
   position: relative;
-  padding: var(--space-5) var(--space-4) max(env(safe-area-inset-bottom, 0px), var(--space-6)) var(--space-4);
+  padding: var(--space-5) var(--space-4)
+           max(env(safe-area-inset-bottom, 0px), env(keyboard-inset-height, 0px), var(--space-6))
+           var(--space-4);
   background-color: var(--bg-secondary);
   border-top: 1px solid var(--border);
   display: flex;
@@ -376,7 +384,7 @@ pre code {
   border-radius: var(--radius-md);
   padding: var(--space-3);
   font-family: var(--font-mono);
-  font-size: var(--text-md);
+  font-size: var(--text-input);  /* ≥16px prevents iOS auto-zoom on focus */
   resize: none;
   min-height: 44px;
   max-height: 150px;


### PR DESCRIPTION
  Description:

  Fixes the mobile keyboard experience so the chat UI resizes naturally when the soft keyboard opens/closes, instead of overlapping, zooming, or jumping
  around.

  Changes

   - Remove position: fixed layout — replaced with height: 100dvh which dynamically shrinks when the mobile keyboard opens (CSS-native, no JS needed on
  Chrome/Android)
   - visualViewport fallback for iOS Safari — dvh doesn't track the keyboard on iOS, so we sync #app height and position to
  visualViewport.height/offsetTop. Header stays visible, chat area shrinks, input stays above the keyboard
   - Prevent iOS auto-zoom on focus — new --text-input design token at 1rem (16px); iOS auto-zooms inputs below 16px
   - Lock viewport scale — maximum-scale=1, user-scalable=no and touch-action constraints prevent stuck-zoom states after keyboard dismiss
   - VirtualKeyboard API for Chrome/Edge — opt-in to overlaysContent mode, enabling env(keyboard-inset-height) for precise keyboard avoidance
   - Smooth transition — 0.25s ease-out on height/transform so keyboard open/close animates instead of snapping

  Testing

Manually tested on Iphone (Chome, Safari, Firefox)

Before: 

https://github.com/user-attachments/assets/16a5afef-3227-46f8-812b-93b9d3fe30c1



After:

https://github.com/user-attachments/assets/391a22f6-26ac-4179-9d16-85919c0a821b

